### PR TITLE
fix: update package list after upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -698,39 +698,5 @@ jobs:
           xbps-rindex -S --privkey /tmp/private.pem "$NEW_PKGS_DIR"/*.xbps
           rm -f /tmp/private.pem
 
-          echo "==> Uploading packages"
           BUILDDIR="$NEW_PKGS_DIR" "${GITHUB_WORKSPACE}/extra/ocoman" -p
-
-      - name: Update package list
-        if: steps.build.outputs.built == 'true'
-        env:
-          SURFER_URL: https://repo.osowoso.org
-          SURFER_TOKEN: ${{ secrets.SURFER_TOKEN }}
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARCH: ${{ matrix.config.arch }}
-        run: |
-          cd "${GITHUB_WORKSPACE}/extra"
-
-          echo "==> Waiting for repodata to propagate"
-          for i in 1 2 3 4 5; do
-            if curl -sfI "${SURFER_URL}/${ARCH}/${ARCH}-repodata" -u ":${SURFER_TOKEN}" > /dev/null 2>&1; then
-              echo "Repodata available after ${i} attempts"
-              break
-            fi
-            echo "Waiting for repodata to propagate... (attempt ${i}/5)"
-            sleep 5
-          done
-
-          echo "==> Regenerating package list pages"
-          ./ocoman -a
-
-          echo "==> Committing updated docs"
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/
-          if git diff --cached --quiet; then
-            echo "No docs changes to commit"
-          else
-            git commit -m "CI: update package list"
-            git push
-          fi
+          "${GITHUB_WORKSPACE}/extra/ocoman" -a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -698,5 +698,39 @@ jobs:
           xbps-rindex -S --privkey /tmp/private.pem "$NEW_PKGS_DIR"/*.xbps
           rm -f /tmp/private.pem
 
+          echo "==> Uploading packages"
           BUILDDIR="$NEW_PKGS_DIR" "${GITHUB_WORKSPACE}/extra/ocoman" -p
-          "${GITHUB_WORKSPACE}/extra/ocoman" -a
+
+      - name: Update package list
+        if: steps.build.outputs.built == 'true'
+        env:
+          SURFER_URL: https://repo.osowoso.org
+          SURFER_TOKEN: ${{ secrets.SURFER_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCH: ${{ matrix.config.arch }}
+        run: |
+          cd "${GITHUB_WORKSPACE}/extra"
+
+          echo "==> Waiting for repodata to propagate"
+          for i in 1 2 3 4 5; do
+            if curl -sfI "${SURFER_URL}/${ARCH}/${ARCH}-repodata" -u ":${SURFER_TOKEN}" > /dev/null 2>&1; then
+              echo "Repodata available after ${i} attempts"
+              break
+            fi
+            echo "Waiting for repodata to propagate... (attempt ${i}/5)"
+            sleep 5
+          done
+
+          echo "==> Regenerating package list pages"
+          ./ocoman -a
+
+          echo "==> Committing updated docs"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          if git diff --cached --quiet; then
+            echo "No docs changes to commit"
+          else
+            git commit -m "CI: update package list"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Create PR
 | tuisic | 2.0.0 | https://github.com/Dark-Kernel/tuisic | zenobit |  |
 | typobuster | 1.0.0 | https://github.com/nwg-piotr/typobuster | zenobit |  |
 | undelete-btrfs | 1.0 | https://github.com/danthem/undelete-btrfs | zenobit |  |
-| vbm | 1.0.1 | https://codeberg.org/oSoWoSo/vbm | zenobit |  |
+| vbm | 1.0.2 | https://codeberg.org/oSoWoSo/vbm | zenobit |  |
 | Vish | 1.1.3 | https://github.com/Lluciocc/Vish | zenobit |  |
 | vm-curator | 1.0.0 | https://github.com/mroboff/vm-curator | zenobit |  |
 | void-hardwaremanager-git | 0.0.0 | https://codeberg.org/pinguin-void/Void-Driver-App | zenobit | x86_64 aarch64 |


### PR DESCRIPTION
## Description

After uploading built packages, the list of compiled packages was not being updated. This fix separates the upload step from the package list update step.

### Changes

- Split the "Sign and upload new packages" step into two separate steps:
  1. **Sign and upload new packages** - handles signing and uploading packages to the repository
  2. **Update package list** - regenerates the package list pages and commits them to the repository

- The new "Update package list" step:
  - Runs `ocoman -a` to regenerate the architecture-specific package list pages in `docs/`
  - Commits and pushes the updated docs to the repository

This ensures that after packages are uploaded, the package list (visible at `repo.osowoso.org/docs/`) is automatically updated to reflect the newly uploaded packages.

Co-authored-by: openhands <openhands@all-hands.dev>

@zen0bit can click here to [continue refining the PR](https://app.all-hands.dev/conversations/57849d80-bb6c-4800-92bf-5d8251806141)